### PR TITLE
add metadata to blogs

### DIFF
--- a/blog/2021-02-23/the-algorithm-its-working.md
+++ b/blog/2021-02-23/the-algorithm-its-working.md
@@ -1,5 +1,7 @@
 title: The Algorithm; It's Working!
 oldTitle: TheAlgorithmItsWorking
+keywords: Oceancap, ADASTA-60, rank, market
+authors: Tim Daubenschütz
 ---
 
 On Feb 18, 2021, the maintainer of the "[Oceancap - Datapool Evaluation and

--- a/blog/2021-03-01/scaling-ethereum-one-tx-at-a-time.md
+++ b/blog/2021-03-01/scaling-ethereum-one-tx-at-a-time.md
@@ -1,5 +1,8 @@
 title: Scaling Ethereum One Tx At A Time
 oldTitle: ScalingEthereumOneTxAtATime
+keywords: WebRTC, WebTorrent, Web3
+authors: Tim Daubenschütz
+image: https://rugpullindex.com/instant-screencap.png
 ---
 
 With regards to building rugpullindex.com, there are currently two problems

--- a/blog/2021-03-07/thank-you-for-voting.md
+++ b/blog/2021-03-07/thank-you-for-voting.md
@@ -1,5 +1,7 @@
 title: Thank You For Voting
 oldTitle: ThankYouForVoting
+keywords: OceanDAO, proposal, vote
+authors: Tim Daubenschütz
 ---
 
 On Friday, March 5, 2021, OceanDAO's round 3 vote finished. If you browsed the

--- a/blog/2021-03-15/the-performance-graph.md
+++ b/blog/2021-03-15/the-performance-graph.md
@@ -1,5 +1,8 @@
 title: The Performance Graph
 oldTitle: ThePerformanceGraph
+keywords: chart, historical performance, update
+authors: Tim Daubenschuetz
+image: https://rugpullindex.com/firstperformancetry.png
 ---
 
 In [OceanDAO Round

--- a/blog/2021-04-05/termux-maintenance.md
+++ b/blog/2021-04-05/termux-maintenance.md
@@ -1,5 +1,7 @@
 title: Termux Maintenance
 oldTitle: TermuxMaintenance
+keywords: ssh, f-droid, holidays, easter, detox
+authors: Tim Daubenschuetz
 ---
 
 I felt stressed before easter. Through COVID lockdowns and all, I ended up

--- a/blog/2021-04-21/major-performance-improvement-is-live.md
+++ b/blog/2021-04-21/major-performance-improvement-is-live.md
@@ -1,5 +1,7 @@
 title: Major Performance Improvement is Live
 oldTitle: MajorPerformanceImprovementisLive
+keywords: cache, speed, improvements, svg-line-chart
+authors: Tim Daubenschuetz
 ---
 
 Hey,

--- a/blog/2021-05-03/meditations-on-monetizations.md
+++ b/blog/2021-05-03/meditations-on-monetizations.md
@@ -1,5 +1,7 @@
 title: Meditations on Monetizations
 oldTitle: MeditationsonMonetizations
+keywords: OceanDAO, funding, capital, ads, income
+authors: Tim Daubenschütz
 ---
 
 Hi yall,

--- a/blog/2021-05-13/quick-update.md
+++ b/blog/2021-05-13/quick-update.md
@@ -1,5 +1,7 @@
 title: Quick Update
 oldTitle: QuickUpdate
+keywords: update, development, rollups
+authors: Tim Daubenschütz
 ---
 
 Here's a quick update on the things that I've been up to in the last few

--- a/blog/2021-05-26/how-plausible-are-our-website-analytics.md
+++ b/blog/2021-05-26/how-plausible-are-our-website-analytics.md
@@ -1,5 +1,8 @@
 title: How "Plausible" are Our Website Analytics
 oldTitle: HowPlausibleareOurWebsiteAnalytics
+keywords: analytics, plausible, cloudflare, vistors, tracking
+image: https://rugpullindex.com/plausiblesixmonths.png
+authors: Tim Daubenschütz
 ---
 
 From rugpullindex's first days, I made its website analytics

--- a/blog/2021-06-07/adjustment-to-gini-coefficient-calculation.md
+++ b/blog/2021-06-07/adjustment-to-gini-coefficient-calculation.md
@@ -1,5 +1,8 @@
 title: Adjustment to Gini Coefficient Calculation
 oldTitle: AdjustmenttoGiniCoefficientCalculation
+keywords: gini coefficient, ranking
+image: https://rugpullindex.com/vorsta2.png
+authors: Tim Daubenschütz
 ---
 
 Hi there,

--- a/blog/2021-06-10/introducing-honeybatcher.md
+++ b/blog/2021-06-10/introducing-honeybatcher.md
@@ -1,5 +1,6 @@
 title: Introducing Honeybatcher
 oldTitle: IntroducingHoneybatcher
+keywords: ethereum, rollup, gas fees, pessimistic rollup, EVM
 ---
 
 In several previous updates, I talked about how difficult it is for RPI to

--- a/blog/2021-06-10/introducing-honeybatcher.md
+++ b/blog/2021-06-10/introducing-honeybatcher.md
@@ -1,6 +1,7 @@
 title: Introducing Honeybatcher
 oldTitle: IntroducingHoneybatcher
 keywords: ethereum, rollup, gas fees, pessimistic rollup, EVM
+authors: Tim Daubenschütz
 ---
 
 In several previous updates, I talked about how difficult it is for RPI to

--- a/blog/2021-06-25/generating-valuable-insights-from-speaking-with-rpi-users.md
+++ b/blog/2021-06-25/generating-valuable-insights-from-speaking-with-rpi-users.md
@@ -1,5 +1,8 @@
 title: Generating valuable insights from speaking with RPI users
 oldTitle: GeneratingvaluableinsightsfromspeakingwithRPIusers
+keywords: users, feedback, business development
+image: https://rugpullindex.com/rice1.png
+authors: Scott Milat
 ---
 
 #### Long time listener, first time caller

--- a/blog/2021-07-02/built-on-stolen-data.md
+++ b/blog/2021-07-02/built-on-stolen-data.md
@@ -1,5 +1,7 @@
 title: Built on Stolen Data
 oldTitle: BuiltonStolenData
+keywords: github, copilot, gpl, open source, license
+authors: Tim Daubenschütz
 ---
 
 A few days ago, GitHub released a new tool for developers called

--- a/blog/2021-07-29/on-the-value-of-product-and-distribution.md
+++ b/blog/2021-07-29/on-the-value-of-product-and-distribution.md
@@ -1,5 +1,7 @@
 title: On The Value Of Product And Distribution
 oldTitle: OnTheValueOfProductAndDistribution
+keywords: product update, self hosting, design
+authors: Tim Daubenschütz
 ---
 
 Quite some time has passed since I last wrote a coherent article on this blog.

--- a/blog/2021-08-02/improving-the-gini-coefficient-formulas-accuracy.md
+++ b/blog/2021-08-02/improving-the-gini-coefficient-formulas-accuracy.md
@@ -1,5 +1,7 @@
 title: Improving the Gini Coefficient Formula's Accuracy
 oldTitle: ImprovingtheGiniCoefficientFormulasAccuracy
+keywords: gini coefficient, specification
+authors: Tim Daubenschütz
 ---
 
 Just a few days ago, to my big surprise, Vitalik released a blog post about

--- a/blog/2021-08-17/loadtests-on-erigon-node.md
+++ b/blog/2021-08-17/loadtests-on-erigon-node.md
@@ -1,5 +1,7 @@
 title: Loadtests on Erigon Node
 oldTitle: LoadtestsonErigonNode
+keywords: ethereum, full node, benchmark
+authors: Tim Daubenschütz
 ---
 
 Since we're dogfooding our latest addition to the RPI API, namely its [shared

--- a/blog/2021-08-25/on-building-the-infamous-version-2.md
+++ b/blog/2021-08-25/on-building-the-infamous-version-2.md
@@ -1,5 +1,7 @@
 title: On Building The Infamous "Version 2"
 oldTitle: OnBuildingTheInfamousVersion2
+keywords: version 2, v2, todo
+authors: Tim Daubenschütz
 ---
 
 The last month or so has been frustrating to develop RPI. I'd say there are a

--- a/blog/2021-09-21/were-not-a-startup.md
+++ b/blog/2021-09-21/were-not-a-startup.md
@@ -1,5 +1,7 @@
 title: We're NOT A Startup
 oldTitle: WereNOTAStartup
+keywords: anti company, startup, operations, vision, mission
+authors: Tim Daubenschütz
 ---
 
 In less than two months, on November 13, 2021, RPI will celebrate its first

--- a/blog/2021-09-27/is-competition-for-losers.md
+++ b/blog/2021-09-27/is-competition-for-losers.md
@@ -1,5 +1,7 @@
 title: Is Competition For Losers?
 oldTitle: IsCompetitionForLosers
+keywords: peter thiel, competition, healthy competition
+authors: Tim Daubenschütz
 ---
 
 A common believe in the startup scene is that competition is for losers and

--- a/blog/2021-10-15/Focus.md
+++ b/blog/2021-10-15/Focus.md
@@ -1,5 +1,7 @@
 title: Focus
 oldTitle: Focus
+keywords: strategy, API, metadata, funding
+authors: Tim Daubenschütz
 ---
 
 In turbulent times, I sometimes tend to undervalue focus. Some people value

--- a/blog/2021-10-18/user-profiles-motivations-in-the-ocean-ecosystem.md
+++ b/blog/2021-10-18/user-profiles-motivations-in-the-ocean-ecosystem.md
@@ -1,5 +1,7 @@
 title: User Profiles & Motivations in the Ocean Ecosystem
 oldTitle: UserProfilesMotivationsintheOceanEcosystem
+keywords: user profiles, ocean ecosystem, stakers, investors, data providers, data buyers
+authors: Scott Milat, Tim Daubenschütz
 ---
 
 The below outlines 8 types of users for rugpullindex.com. 

--- a/blog/2021-10-23/thank-you-next-problem.md
+++ b/blog/2021-10-23/thank-you-next-problem.md
@@ -1,5 +1,7 @@
 title: Thank you, next (problem)!
 oldTitle: Thankyounextproblem
+keywords: progress, rug pull index, overcoming problems, work at RPI
+authors: Tim Daubenschütz
 ---
 
 It's an incredible thing to say, but I think we're getting close to our first

--- a/blog/2021-11-02/Heureka.md
+++ b/blog/2021-11-02/Heureka.md
@@ -1,5 +1,7 @@
 title: Heureka!
 oldTitle: Heureka
+keywords: return on investment, ocean protocol, analytics, outbound clicks
+authors: Tim Daubenschütz
 ---
 
 Countless times throughout maintaining this document, I've worried about the

--- a/blog/2021-11-02/Heureka.md
+++ b/blog/2021-11-02/Heureka.md
@@ -2,6 +2,7 @@ title: Heureka!
 oldTitle: Heureka
 keywords: return on investment, ocean protocol, analytics, outbound clicks
 authors: Tim Daubenschütz
+image: https://rugpullindex.com/shieldio-requests-op-marketplace.png
 ---
 
 Countless times throughout maintaining this document, I've worried about the

--- a/blog/2021-11-15/marketing-week.md
+++ b/blog/2021-11-15/marketing-week.md
@@ -1,5 +1,7 @@
 title: Marketing Week
 oldTitle: MarketingWeek
+keywords: marketing, open source, growth
+authors: Tim Daubenschütz
 ---
 
 It's "Marketing Week", y'all!

--- a/blog/2021-11-16/rpi-vision-and-goals-for-current-and-future-contributors-and-community-members.md
+++ b/blog/2021-11-16/rpi-vision-and-goals-for-current-and-future-contributors-and-community-members.md
@@ -1,5 +1,7 @@
 title: RPI Vision and Goals for Current and Future Contributors and Community Members
 oldTitle: RPIVisionandGoalsforCurrentandFutureContributorsandCommunityMembers
+keywords: vision, metrics, future, community, goal
+authors: Scott Milat, Rug Pull Index
 ---
 
 The below document outlines the most recent vision, goals and key metrics for the RPI project. 


### PR DESCRIPTION
Fixes #7 

- Added metadata includes keywords, authors, and image.
- A philosophy that I have followed is to not add words from the title in keywords. I think from SEO point of view it is redundancy.
- In the blog, *[RPI Vision and Goals for Current and Future Contributors and Community Members](https://rugpullindex.com/blog/2021-11-16/rpi-vision-and-goals-for-current-and-future-contributors-and-community-members)* I have added authors as `Scott Milat, Rug Pull Index` to signify that this was written by the RPI team.